### PR TITLE
Remove Unneeded Reference to HttpAPIClient class

### DIFF
--- a/GitHubWebHookTool/Functions/ReceiveFromWebHook.cs
+++ b/GitHubWebHookTool/Functions/ReceiveFromWebHook.cs
@@ -15,12 +15,10 @@ namespace GitHubWebHookTool
     public class ReceiveFromWebHook
     {
         private readonly IPushService _pushService;
-        private readonly HttpAPIClient _httpAPIClient;
 
-        public ReceiveFromWebHook(IPushService pushService, HttpAPIClient httpAPIClient)
+        public ReceiveFromWebHook(IPushService pushService)
         {
             _pushService = pushService;
-            _httpAPIClient = httpAPIClient;
         }
 
         [FunctionName("ReceiveFromWebHook")]


### PR DESCRIPTION
Removed the reference to the HttpAPIClient from the ReceiveWebHook Azure function