### PR TITLE
Create GitHubWebHookToolInput

### DIFF
--- a/GitHubWebHookEngine/API/HttpAPIClient.cs
+++ b/GitHubWebHookEngine/API/HttpAPIClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Json;
+﻿using GitHubWebHookShared.Models;
+using System.Net.Http.Json;
 
 namespace GitHubWebHookEngine.API
 {
@@ -6,16 +7,20 @@ namespace GitHubWebHookEngine.API
     {
         public HttpClient _Client { get; }
 
-        public HttpAPIClient(HttpClient httpClient)
+        private readonly GitHubWebHookToolInput _gitHubWebHookToolInput = null;
+
+        public HttpAPIClient(HttpClient httpClient, GitHubWebHookToolInput gitHubWebHookToolInput)
         {
-            if(httpClient == null)
+            _gitHubWebHookToolInput = gitHubWebHookToolInput;
+
+            if (httpClient == null)
             {
                 return;
             }
 
             if(httpClient.BaseAddress == null)
             {
-                httpClient.BaseAddress = new Uri(Environment.GetEnvironmentVariable("GitHubAPIUrl"));
+                httpClient.BaseAddress = new Uri(_gitHubWebHookToolInput.GitHubAPIUrl);
             }
 
             httpClient.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("AppName", "1.0"));
@@ -26,7 +31,7 @@ namespace GitHubWebHookEngine.API
 
             if (httpClient.DefaultRequestHeaders?.Authorization == null)
             {
-                httpClient.DefaultRequestHeaders.Authorization = httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Environment.GetEnvironmentVariable("PrivateToken"));
+                httpClient.DefaultRequestHeaders.Authorization = httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", _gitHubWebHookToolInput.PrivateToken);
             }
 
             _Client = httpClient;

--- a/GitHubWebHookShared/Models/GitHubWebHookToolInput.cs
+++ b/GitHubWebHookShared/Models/GitHubWebHookToolInput.cs
@@ -1,0 +1,8 @@
+﻿namespace GitHubWebHookShared.Models
+{
+    public class GitHubWebHookToolInput
+    {
+        public string GitHubAPIUrl { get; set; }
+        public string PrivateToken { get; set; }
+    }
+}

--- a/GitHubWebHookTool/Startup.cs
+++ b/GitHubWebHookTool/Startup.cs
@@ -1,8 +1,10 @@
 ﻿using GitHubWebHookEngine.API;
 using GitHubWebHookEngine.Services;
 using GitHubWebHookEngine.Services.Interfaces;
+using GitHubWebHookShared.Models;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 [assembly: FunctionsStartup(typeof(GitHubWebHookTool.Startup))]
 namespace GitHubWebHookTool
@@ -11,6 +13,20 @@ namespace GitHubWebHookTool
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
+            //Environment Variables read from local.settings.json
+
+            bool.TryParse(Environment.GetEnvironmentVariable("AddDelay"), out bool addDelay);
+
+            Int32.TryParse(Environment.GetEnvironmentVariable("DelayInMilliseconds"), out int delayInMilliseconds);
+
+            var gitHubWebHookToolInput = new GitHubWebHookToolInput()
+            {
+                GitHubAPIUrl = Environment.GetEnvironmentVariable("GitHubAPIUrl"),
+                PrivateToken = Environment.GetEnvironmentVariable("PrivateToken"),
+            };
+
+            builder.Services.AddSingleton(gitHubWebHookToolInput);
+
             builder.Services.AddHttpClient<HttpAPIClient>();
 
             builder.Services.AddScoped<IPushService, PushService>();

--- a/GitHubWebHookToolTesterApp/Program.cs
+++ b/GitHubWebHookToolTesterApp/Program.cs
@@ -10,12 +10,13 @@ var builder = new ConfigurationBuilder()
 
 var config = builder.Build();
 
-var httpClient = new HttpClient();
+var gitHubWebHookToolInput = new GitHubWebHookToolInput()
+{
+    GitHubAPIUrl = config["GitHubAPIURL"],
+    PrivateToken = config["PrivateToken"],
+};
 
-httpClient.BaseAddress = new Uri(config["GitHubAPIURL"]);
-httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", config["PrivateToken"]);
-
-var httpAPIClient = new HttpAPIClient(httpClient);
+var httpAPIClient = new HttpAPIClient(new HttpClient(), gitHubWebHookToolInput);
 
 var commitService = new CommitService(httpAPIClient);
 


### PR DESCRIPTION
Created a GitHubWebHookToolInput class which is used to pass the GitHubAPIURL and PrivateToken from the GitHubWebHookTool Azure Function to the GitHubWebHookEngine